### PR TITLE
Add HelpDialog component to give context on availability

### DIFF
--- a/src/components/Availability.js
+++ b/src/components/Availability.js
@@ -18,8 +18,8 @@ export default function Availability({ entry }) {
             return (
                 <div>
                     No date-specific data available.
-                    <HelpDialog 
-                        title='No date-specific data available.' 
+                    <HelpDialog
+                        title="No date-specific data available."
                         text="We were able to determine that there are available appointments,
                         but we can't tell when or how many. Click the sign up button to learn more
                         from the location's website."

--- a/src/components/Availability.js
+++ b/src/components/Availability.js
@@ -1,3 +1,5 @@
+import HelpDialog from "./HelpDialog";
+
 export default function Availability({ entry }) {
     console.log(entry.hasAppointments);
     if (!entry.hasAppointments) {
@@ -13,7 +15,17 @@ export default function Availability({ entry }) {
             }
         }
         if (!availableSlots.length && entry.hasAppointments) {
-            return <div>No date-specific data available.</div>;
+            return (
+                <div>
+                    No date-specific data available.
+                    <HelpDialog 
+                        title='No date-specific data available.' 
+                        text="We were able to determine that there are available appointments,
+                        but we can't tell when or how many. Click the sign up button to learn more
+                        from the location's website."
+                    />
+                </div>
+            );
         } else {
             return (
                 <div>

--- a/src/components/HelpDialog.js
+++ b/src/components/HelpDialog.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Tooltip from '@material-ui/core/Tooltip';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
@@ -10,7 +11,9 @@ export default function HelpDialog(props) {
     const [helpOpen, setHelpOpen] = React.useState(false);
 
     return (<span>
-        <HelpOutlineIcon fontSize='small' onClick={() => setHelpOpen(true)}/>
+        <Tooltip title='Click for more info'>
+            <HelpOutlineIcon fontSize='small' onClick={() => setHelpOpen(true)}/>
+        </Tooltip>
         <Dialog open={helpOpen} onClose={() => setHelpOpen(false)}>
             <DialogTitle id="about-dialog-title">{props.title}</DialogTitle>
             <DialogContent>	

--- a/src/components/HelpDialog.js
+++ b/src/components/HelpDialog.js
@@ -1,0 +1,24 @@
+import React from "react";
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import Button from "@material-ui/core/Button";
+
+export default function HelpDialog(props) {
+    const [helpOpen, setHelpOpen] = React.useState(false);
+
+    return (<span>
+        <HelpOutlineIcon fontSize='small' onClick={() => setHelpOpen(true)}/>
+        <Dialog open={helpOpen} onClose={() => setHelpOpen(false)}>
+            <DialogTitle id="about-dialog-title">{props.title}</DialogTitle>
+            <DialogContent>	
+                <DialogContentText id="about-dialog-description">
+                    <p>{props.text}</p>
+                </DialogContentText>
+                <Button onClick={() => setHelpOpen(false)}>OK</Button>
+            </DialogContent>
+        </Dialog>
+    </span>);
+}

--- a/src/components/HelpDialog.js
+++ b/src/components/HelpDialog.js
@@ -15,6 +15,7 @@ export default function HelpDialog(props) {
             <Tooltip title="Click for more info">
                 <HelpOutlineIcon
                     fontSize="small"
+                    color="action"
                     onClick={() => setHelpOpen(true)}
                 />
             </Tooltip>

--- a/src/components/HelpDialog.js
+++ b/src/components/HelpDialog.js
@@ -1,6 +1,6 @@
 import React from "react";
-import Tooltip from '@material-ui/core/Tooltip';
-import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
+import Tooltip from "@material-ui/core/Tooltip";
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogContent from "@material-ui/core/DialogContent";
@@ -10,18 +10,23 @@ import Button from "@material-ui/core/Button";
 export default function HelpDialog(props) {
     const [helpOpen, setHelpOpen] = React.useState(false);
 
-    return (<span>
-        <Tooltip title='Click for more info'>
-            <HelpOutlineIcon fontSize='small' onClick={() => setHelpOpen(true)}/>
-        </Tooltip>
-        <Dialog open={helpOpen} onClose={() => setHelpOpen(false)}>
-            <DialogTitle id="about-dialog-title">{props.title}</DialogTitle>
-            <DialogContent>	
-                <DialogContentText id="about-dialog-description">
-                    <p>{props.text}</p>
-                </DialogContentText>
-                <Button onClick={() => setHelpOpen(false)}>OK</Button>
-            </DialogContent>
-        </Dialog>
-    </span>);
+    return (
+        <span>
+            <Tooltip title="Click for more info">
+                <HelpOutlineIcon
+                    fontSize="small"
+                    onClick={() => setHelpOpen(true)}
+                />
+            </Tooltip>
+            <Dialog open={helpOpen} onClose={() => setHelpOpen(false)}>
+                <DialogTitle id="about-dialog-title">{props.title}</DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="about-dialog-description">
+                        <p>{props.text}</p>
+                    </DialogContentText>
+                    <Button onClick={() => setHelpOpen(false)}>OK</Button>
+                </DialogContent>
+            </Dialog>
+        </span>
+    );
 }

--- a/src/components/SignUpLink.js
+++ b/src/components/SignUpLink.js
@@ -43,11 +43,12 @@ export default function SignUpLink({ entry }) {
                 return (
                     <div>
                         No sign-up link available.
-                        <HelpDialog 
-                            title='No sign-up link available.' 
+                        <HelpDialog
+                            title="No sign-up link available."
                             text="The state website (maimmunizations.org/) is not currently providing a sign-up link for this location."
                         />
-                    </div>);
+                    </div>
+                );
             } else if (dateLinkPairs.length === 1) {
                 return (
                     <Button

--- a/src/components/SignUpLink.js
+++ b/src/components/SignUpLink.js
@@ -3,6 +3,7 @@ import Button from "@material-ui/core/Button";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import { useState } from "react";
+import HelpDialog from "./HelpDialog";
 
 const useStyles = makeStyles((theme) => ({
     dateSelectDropdown: {
@@ -39,7 +40,14 @@ export default function SignUpLink({ entry }) {
                 }
             }
             if (!dateLinkPairs.length) {
-                return "No sign-up link available.";
+                return (
+                    <div>
+                        No sign-up link available.
+                        <HelpDialog 
+                            title='No sign-up link available.' 
+                            text="The state website (maimmunizations.org/) is not currently providing a sign-up link for this location."
+                        />
+                    </div>);
             } else if (dateLinkPairs.length === 1) {
                 return (
                     <Button

--- a/src/components/SignUpLink.js
+++ b/src/components/SignUpLink.js
@@ -45,7 +45,7 @@ export default function SignUpLink({ entry }) {
                         No sign-up link available.
                         <HelpDialog
                             title="No sign-up link available."
-                            text="The state website (maimmunizations.org/) is not currently providing a sign-up link for this location."
+                            text="We were unable to retrieve a sign-up link for this location. It's likely that this location is pulling from a wait list and is not scheduling any new appointments."
                         />
                     </div>
                 );


### PR DESCRIPTION
https://github.com/livgust/macovidvaccines.com/issues/7

HelpDialog component includes help icon that you click to see dialog and "OK" button in dialog for closing (also closes if you click outside).

Used to provide additional context in two cases:
- No date-specific data available
- No sign-up link available