### PR TITLE
chore: add nan to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10452,8 +10452,7 @@
         "nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-            "optional": true
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         },
         "nanoid": {
             "version": "3.1.20",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "web-vitals": "^0.2.4"
     },
     "devDependencies": {
-        "@axe-core/react": "^4.1.1"
+        "@axe-core/react": "^4.1.1",
+        "nan": "^2.14.2"
     },
     "scripts": {
         "start": "react-scripts start",


### PR DESCRIPTION
Issue: I was getting the error `Error: Cannot find module 'nan'` when running `npm ci`. My hypothesis is that I (on a Mac) am seeing this issue and others (PC / Ubuntu users) are not is that the error is thrown from `fsevents` which is platform-specific. 

Ran `npm install` to add `nan` and other related packages to package-lock.json. 
Now I don't get the error when I run `npm ci`. 