### PR TITLE
Add warning when sites are restricted

### DIFF
--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -11,6 +11,7 @@ import SignUpLink from "./components/SignUpLink";
 import MoreInformation from "./components/MoreInformation";
 import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
 import HelpDialog from "./components/HelpDialog";
+import Typography from "@material-ui/core/Typography";
 
 export function transformData(data) {
     return data.map((entry, index) => {
@@ -53,14 +54,15 @@ const useStyles = makeStyles((theme) => ({
         "padding-top": theme.spacing(2),
         "padding-bottom": theme.spacing(2),
     },
-    locationTitle: {
+    restrictionNotice: {
         display: "flex",
         alignItems: "center",
         flexWrap: "wrap",
+        color: theme.palette.text.primary,
     },
     restrictionIcon: {
         color: theme.palette.warning.dark,
-        "padding-left": theme.spacing(1),
+        "padding-right": theme.spacing(1),
     },
 }));
 
@@ -167,22 +169,25 @@ function RestrictionNotifier({ entry }) {
 
     const classes = useStyles();
     return hasRestriction ? (
-        <HelpDialog
-            icon={ErrorOutlineIcon}
-            iconProps={{ className: classes.restrictionIcon }}
-            tooltipText={"This site may be restricted"}
-            title="This site may be restricted"
-            text={
-                <>
-                    <p>
-                        We have flagged this site as restricted based on the
-                        following information (located under "MORE
-                        INFORMATION"):
-                    </p>
-                    <p>"{restrictionText}"</p>
-                </>
-            }
-        />
+        <div className={classes.restrictionNotice}>
+            <HelpDialog
+                icon={ErrorOutlineIcon}
+                iconProps={{ className: classes.restrictionIcon }}
+                tooltipText={"This site may be restricted"}
+                title="This site may be restricted"
+                text={
+                    <>
+                        <p>
+                            We have flagged this site as restricted based on the
+                            following information (located under "MORE
+                            INFORMATION"):
+                        </p>
+                        <p>"{restrictionText}"</p>
+                    </>
+                }
+            />
+            <Typography>May be restricted</Typography>
+        </div>
     ) : null;
 }
 
@@ -195,10 +200,14 @@ function LocationCard({ entry, className }) {
                     title={
                         <div className={classes.locationTitle}>
                             <span>{entry.location}</span>
-                            <RestrictionNotifier entry={entry} />
                         </div>
                     }
-                    subheader={<div>{entry.city}</div>}
+                    subheader={
+                        <>
+                            <RestrictionNotifier entry={entry} />
+                            <div>{entry.city}</div>
+                        </>
+                    }
                 />
                 <CardContent>
                     <Availability entry={entry} />

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -58,6 +58,7 @@ const useStyles = makeStyles((theme) => ({
         display: "flex",
         alignItems: "center",
         flexWrap: "wrap",
+        cursor: "pointer",
         color: theme.palette.text.primary,
     },
     restrictionIcon: {
@@ -169,25 +170,24 @@ function RestrictionNotifier({ entry }) {
 
     const classes = useStyles();
     return hasRestriction ? (
-        <div className={classes.restrictionNotice}>
-            <HelpDialog
-                icon={ErrorOutlineIcon}
-                iconProps={{ className: classes.restrictionIcon }}
-                tooltipText={"This site may be restricted"}
-                title="This site may be restricted"
-                text={
-                    <>
-                        <p>
-                            We have flagged this site as restricted based on the
-                            following information (located under "MORE
-                            INFORMATION"):
-                        </p>
-                        <p>"{restrictionText}"</p>
-                    </>
-                }
-            />
+        <HelpDialog
+            className={classes.restrictionNotice}
+            icon={ErrorOutlineIcon}
+            iconProps={{ className: classes.restrictionIcon }}
+            title="This site may be restricted"
+            text={
+                <>
+                    <p>
+                        We have flagged this site as restricted based on the
+                        following information (located under "MORE
+                        INFORMATION"):
+                    </p>
+                    <p>"{restrictionText}"</p>
+                </>
+            }
+        >
             <Typography>May be restricted</Typography>
-        </div>
+        </HelpDialog>
     ) : null;
 }
 

--- a/src/components/HelpDialog.js
+++ b/src/components/HelpDialog.js
@@ -10,9 +10,10 @@ import Button from "@material-ui/core/Button";
 export default function HelpDialog({
     title,
     text,
-    tooltipText,
     icon,
     iconProps,
+    children,
+    className,
 }) {
     const [helpOpen, setHelpOpen] = React.useState(false);
 
@@ -20,13 +21,19 @@ export default function HelpDialog({
 
     return (
         <>
-            <Tooltip arrow title={tooltipText || "Click for more info"}>
-                <IconComponent
-                    fontSize="small"
-                    color="action"
-                    onClick={() => setHelpOpen(true)}
-                    {...iconProps}
-                />
+            <Tooltip
+                arrow
+                title={"Click for more info"}
+                placement="bottom-start"
+            >
+                <span onClick={() => setHelpOpen(true)} className={className}>
+                    <IconComponent
+                        fontSize="small"
+                        color="action"
+                        {...iconProps}
+                    />
+                    {children}
+                </span>
             </Tooltip>
             <Dialog open={helpOpen} onClose={() => setHelpOpen(false)}>
                 <DialogTitle id="about-dialog-title">{title}</DialogTitle>

--- a/src/components/HelpDialog.js
+++ b/src/components/HelpDialog.js
@@ -7,27 +7,36 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import Button from "@material-ui/core/Button";
 
-export default function HelpDialog(props) {
+export default function HelpDialog({
+    title,
+    text,
+    tooltipText,
+    icon,
+    iconProps,
+}) {
     const [helpOpen, setHelpOpen] = React.useState(false);
 
+    const IconComponent = icon || HelpOutlineIcon;
+
     return (
-        <span>
-            <Tooltip title="Click for more info">
-                <HelpOutlineIcon
+        <>
+            <Tooltip arrow title={tooltipText || "Click for more info"}>
+                <IconComponent
                     fontSize="small"
                     color="action"
                     onClick={() => setHelpOpen(true)}
+                    {...iconProps}
                 />
             </Tooltip>
             <Dialog open={helpOpen} onClose={() => setHelpOpen(false)}>
-                <DialogTitle id="about-dialog-title">{props.title}</DialogTitle>
+                <DialogTitle id="about-dialog-title">{title}</DialogTitle>
                 <DialogContent>
                     <DialogContentText id="about-dialog-description">
-                        <p>{props.text}</p>
+                        <p>{text}</p>
                     </DialogContentText>
                     <Button onClick={() => setHelpOpen(false)}>OK</Button>
                 </DialogContent>
             </Dialog>
-        </span>
+        </>
     );
 }


### PR DESCRIPTION
If we see text suggesting a site is only open to residents of a certain area, we will show an icon with hover text:
![image](https://user-images.githubusercontent.com/8116945/108254436-0071fc00-7129-11eb-916a-6e0ba494201f.png)

When clicked, it will show a dialog with more context.
![image](https://user-images.githubusercontent.com/8116945/108254287-d02a5d80-7128-11eb-88e7-c3a2f1f2ca52.png)

Also slightly refactors the HelpDialog component; make sure that still works (click a ? icon and make sure it shows a Dialog)

Future-proofing: if `data` passes in a "restrictions" item, will use that to as source-of-truth instead of doing a regex against More Information (state-sponsored sites only).

ALSO I changed the default sort to alphabetical based on user feeback.