### PR TITLE
Restriction box detailing

### DIFF
--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -177,12 +177,12 @@ function RestrictionNotifier({ entry }) {
             title="This site may be restricted"
             text={
                 <>
+                <p>"{restrictionText}"</p>
                     <p>
                         We have flagged this site as restricted based on the
-                        following information (located under "MORE
-                        INFORMATION"):
+                        above information (located under "MORE
+                        INFORMATION").
                     </p>
-                    <p>"{restrictionText}"</p>
                 </>
             }
         >

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -177,7 +177,7 @@ function RestrictionNotifier({ entry }) {
             title="This site may be restricted"
             text={
                 <>
-                <p>"{restrictionText}"</p>
+                <p className={classes.restrictionNotice}>"{restrictionText}"</p>
                     <p>
                         We have flagged this site as restricted based on the
                         above information (located under "MORE


### PR DESCRIPTION
Format the restriction box to put the information that users need to see first, and don't format it a hard-to-read light grey.
It looks like that formatting is an error in how HelpDialog is implemented, but I'm not sure.

Other changes worth doing but not implemented here would be: 1) tightening up the space after the heading, 2) copying the yellow/amber iconography into the dialog, 3) formatting the OK button with an affordance for clicking. I'm sure someone more experienced in React could do those much faster than I.

**Before**:
![Screen Shot 2021-02-17 at 5 13 47 PM](https://user-images.githubusercontent.com/1270718/108275219-06c1a180-7144-11eb-8844-b87445859b10.png)


**After**:
![Screen Shot 2021-02-17 at 5 13 31 PM](https://user-images.githubusercontent.com/1270718/108275204-01645700-7144-11eb-9208-c1a7151b8b8d.png)
