### PR TITLE
Don't show restriction for mass sites (Foxborough, Fenway)

### DIFF
--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -163,10 +163,14 @@ function RestrictionNotifier({ entry }) {
     } else if (entry.extraData && entry.extraData["Additional Information"]) {
         const text = entry.extraData["Additional Information"];
         if (
-            //"resident" " live" " work" "eligible populations in"
+            // "County residents"
+	    // "eligible residents"
+	    // " live"
+	    // " work"
+	    // "eligible populations in"
             text
                 .toLowerCase()
-                .match(/(resident|\slive|\swork|eligible\spopulations\sin)/)
+                .match(/(county\sresidents|eligible\sresidents|\slive|\swork|eligible\spopulations\sin)/)
         ) {
             hasRestriction = true;
             restrictionText = text;


### PR DESCRIPTION
Tighen up the regexp matching.

Don't trigger on /resident/, which improperly matches on both Fenway
and Foxborough as they have this text now:

  ...
  and residents and staff of public and private low-income and
  affordable senior housing

Instead, trigger on either /County residents/ or /eligible residents/,
to cover this case:

  This clinic is for eligible Franklin County residents under phase 1

and:

  These clinics are for eligible residents under the Massachusetts