### PR TITLE
Stale data indicator

### DIFF
--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -1,18 +1,19 @@
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
 
-import Loader from "react-loader";
-import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core";
-import Card from "@material-ui/core/Card";
-import CardHeader from "@material-ui/core/CardHeader";
-import CardContent from "@material-ui/core/CardContent";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Switch from "@material-ui/core/Switch";
 import Availability from "./components/Availability";
-import SignUpLink from "./components/SignUpLink";
-import MoreInformation from "./components/MoreInformation";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
 import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 import HelpDialog from "./components/HelpDialog";
+import Loader from "react-loader";
+import MoreInformation from "./components/MoreInformation";
+import React, { useState, useEffect } from "react";
+import SignUpLink from "./components/SignUpLink";
+import StaleDataIndicator from "./components/StaleDataIndicator";
+import Switch from "@material-ui/core/Switch";
 import Typography from "@material-ui/core/Typography";
 
 export function transformData(data) {
@@ -28,6 +29,7 @@ export function transformData(data) {
             signUpLink: entry.signUpLink || null,
             extraData: entry.extraData || null,
             restrictions: entry.restrictions || null,
+            timestamp: entry.timestamp ? new Date(entry.timestamp) : null,
         };
     });
 }
@@ -166,13 +168,15 @@ function RestrictionNotifier({ entry }) {
         const text = entry.extraData["Additional Information"];
         if (
             // "County residents"
-	    // "eligible residents"
-	    // " live"
-	    // " work"
-	    // "eligible populations in"
+            // "eligible residents"
+            // " live"
+            // " work"
+            // "eligible populations in"
             text
                 .toLowerCase()
-                .match(/(county\sresidents|eligible\sresidents|\slive|\swork|eligible\spopulations\sin)/)
+                .match(
+                    /(county\sresidents|eligible\sresidents|\slive|\swork|eligible\spopulations\sin)/
+                )
         ) {
             hasRestriction = true;
             restrictionText = text;
@@ -198,7 +202,9 @@ function RestrictionNotifier({ entry }) {
                 title="This site may be restricted"
                 text={
                     <>
-                    <p className={classes.restrictionNotice}>"{restrictionText}"</p>
+                        <p className={classes.restrictionNotice}>
+                            "{restrictionText}"
+                        </p>
                         <p>
                             We have flagged this site as restricted based on the
                             above information (located under "MORE
@@ -228,6 +234,7 @@ function LocationCard({ entry, className }) {
                         <>
                             <RestrictionNotifier entry={entry} />
                             <div>{entry.city}</div>
+                            <StaleDataIndicator timestamp={entry.timestamp} />
                         </>
                     }
                 />

--- a/src/components/StaleDataIndicator.js
+++ b/src/components/StaleDataIndicator.js
@@ -1,9 +1,23 @@
-export const staleMinutesDefault = 10;
+import { makeStyles } from "@material-ui/core";
+import HistoryOutlinedIcon from "@material-ui/icons/HistoryOutlined";
+
+export const staleMinutesDefault = 8;
+
+const useStyles = makeStyles((theme) => ({
+    staleIndicator: {
+        display: "flex",
+        alignItems: "center",
+        flexWrap: "wrap",
+        color: theme.palette.warning.dark,
+    },
+}));
 
 export default function StaleDataIndicator({
     timestamp,
     staleMinutesOverride,
 }) {
+    const classes = useStyles();
+
     let staleMinutes = staleMinutesDefault;
     if (staleMinutesOverride || staleMinutesOverride === 0) {
         staleMinutes = staleMinutesOverride;
@@ -28,6 +42,11 @@ export default function StaleDataIndicator({
             message = `${daysBeforeNow} day${daysBeforeNow > 1 ? "s" : ""}`;
         }
 
-        return <div>{message} ago</div>;
+        return (
+            <div className={classes.staleIndicator}>
+                <HistoryOutlinedIcon />
+                {message} ago
+            </div>
+        );
     }
 }

--- a/src/components/StaleDataIndicator.js
+++ b/src/components/StaleDataIndicator.js
@@ -8,7 +8,11 @@ const useStyles = makeStyles((theme) => ({
         display: "flex",
         alignItems: "center",
         flexWrap: "wrap",
+        color: theme.palette.text.primary,
+    },
+    staleIcon: {
         color: theme.palette.warning.dark,
+        "padding-right": theme.spacing(1),
     },
 }));
 
@@ -27,25 +31,33 @@ export default function StaleDataIndicator({
         return null;
     } else {
         let message = "";
-        const minutesBeforeNow = parseInt(
-            (new Date() - timestamp) / (1000 * 60)
-        );
-        if (minutesBeforeNow < 60) {
-            message = `${minutesBeforeNow} minute${
-                minutesBeforeNow > 1 ? "s" : ""
-            }`;
-        } else if (minutesBeforeNow < 60 * 24) {
-            const hoursBeforeNow = parseInt(minutesBeforeNow / 60);
-            message = `${hoursBeforeNow} hour${hoursBeforeNow > 1 ? "s" : ""}`;
-        } else {
-            const daysBeforeNow = parseInt(minutesBeforeNow / (60 * 24));
-            message = `${daysBeforeNow} day${daysBeforeNow > 1 ? "s" : ""}`;
+        let yesterday = new Date();
+        yesterday.setDate(new Date().getDate() - 1);
+        yesterday.setHours(0, 0, 0, 0);
+
+        // timestamp is today
+        if (timestamp >= new Date().setHours(0, 0, 0, 0)) {
+            // 12:30:31 PM, for example
+            let timeString = new Date(timestamp).toLocaleTimeString("en-US");
+            // chop off the seconds
+            timeString = timeString.replace(/:[0-9]{2}\s/, " ");
+            message = `Last updated ${timeString}`;
+        }
+        // timestamp is yesterday
+        else if (timestamp >= yesterday) {
+            message = "Last updated yesterday";
+        }
+        // timestamp is older than yesterday
+        else {
+            message = `Last updated ${
+                new Date(timestamp).getMonth() + 1
+            }/${new Date(timestamp).getDate()}`;
         }
 
         return (
             <div className={classes.staleIndicator}>
-                <HistoryOutlinedIcon />
-                {message} ago
+                <HistoryOutlinedIcon className={classes.staleIcon} />
+                {message}
             </div>
         );
     }

--- a/src/components/StaleDataIndicator.js
+++ b/src/components/StaleDataIndicator.js
@@ -1,0 +1,33 @@
+export const staleMinutesDefault = 10;
+
+export default function StaleDataIndicator({
+    timestamp,
+    staleMinutesOverride,
+}) {
+    let staleMinutes = staleMinutesDefault;
+    if (staleMinutesOverride || staleMinutesOverride === 0) {
+        staleMinutes = staleMinutesOverride;
+    }
+
+    if (!timestamp || timestamp >= new Date() - staleMinutes * 60 * 1000) {
+        return null;
+    } else {
+        let message = "";
+        const minutesBeforeNow = parseInt(
+            (new Date() - timestamp) / (1000 * 60)
+        );
+        if (minutesBeforeNow < 60) {
+            message = `${minutesBeforeNow} minute${
+                minutesBeforeNow > 1 ? "s" : ""
+            }`;
+        } else if (minutesBeforeNow < 60 * 24) {
+            const hoursBeforeNow = parseInt(minutesBeforeNow / 60);
+            message = `${hoursBeforeNow} hour${hoursBeforeNow > 1 ? "s" : ""}`;
+        } else {
+            const daysBeforeNow = parseInt(minutesBeforeNow / (60 * 24));
+            message = `${daysBeforeNow} day${daysBeforeNow > 1 ? "s" : ""}`;
+        }
+
+        return <div>{message} ago</div>;
+    }
+}

--- a/src/components/StaleDataIndicator.test.js
+++ b/src/components/StaleDataIndicator.test.js
@@ -16,8 +16,8 @@ it("shows no indicator if the data is less than 10 minutes old", async () => {
 });
 
 describe("staleness messaging", () => {
-    it("shows minutes if between staleMinutes and 60 minutes", async () => {
-        const minutesStaleTimestamp = new Date() - 35 * 60 * 1000; // 35 mins stale
+    it("shows time if it's today", async () => {
+        const minutesStaleTimestamp = new Date().setHours(12, 0, 0, 0); // 35 mins stale
         await act(async () => {
             render(
                 <StaleDataIndicator
@@ -27,11 +27,12 @@ describe("staleness messaging", () => {
             );
         });
 
-        expect(screen.getByText("35 minutes ago")).toBeTruthy();
+        expect(screen.getByText("Last updated 12:00 PM")).toBeTruthy();
     });
 
-    it("shows hours if between 1 and 24 hours", async () => {
-        const minutesStaleTimestamp = new Date() - 3 * 60 * 60 * 1000;
+    it("shows 'yesterday' if it was yesterday", async () => {
+        // 24 hrs ago
+        const minutesStaleTimestamp = new Date() - 24 * 60 * 60 * 1000;
         await act(async () => {
             render(
                 <StaleDataIndicator
@@ -41,11 +42,11 @@ describe("staleness messaging", () => {
             );
         });
 
-        expect(screen.getByText("3 hours ago")).toBeTruthy();
+        expect(screen.getByText("Last updated yesterday")).toBeTruthy();
     });
 
-    it("shows days if over 24 hours", async () => {
-        const minutesStaleTimestamp = new Date() - 3 * 24 * 60 * 60 * 1000;
+    it("shows date if older than yesterday", async () => {
+        const minutesStaleTimestamp = new Date("2021-01-21T00:00");
         await act(async () => {
             render(
                 <StaleDataIndicator
@@ -55,20 +56,6 @@ describe("staleness messaging", () => {
             );
         });
 
-        expect(screen.getByText("3 days ago")).toBeTruthy();
-    });
-
-    it("parses singular correctly", async () => {
-        const minutesStaleTimestamp = new Date() - 1 * 60 * 1000;
-        await act(async () => {
-            render(
-                <StaleDataIndicator
-                    timestamp={minutesStaleTimestamp}
-                    staleMinutesOverride={0}
-                />
-            );
-        });
-
-        expect(screen.getByText("1 minute ago")).toBeTruthy();
+        expect(screen.getByText("Last updated 1/21")).toBeTruthy();
     });
 });

--- a/src/components/StaleDataIndicator.test.js
+++ b/src/components/StaleDataIndicator.test.js
@@ -1,0 +1,74 @@
+import { act, render, screen } from "@testing-library/react";
+
+import StaleDataIndicator from "./StaleDataIndicator";
+
+it("shows no indicator if the data is less than 10 minutes old", async () => {
+    const recentTimestamp = new Date() - 9 * 60 * 1000; //9 mins old
+    await act(async () => {
+        render(
+            <StaleDataIndicator
+                timestamp={recentTimestamp}
+                staleMinutesOverride={10}
+            />
+        );
+    });
+    expect(screen.queryByText("ago")).toBeNull();
+});
+
+describe("staleness messaging", () => {
+    it("shows minutes if between staleMinutes and 60 minutes", async () => {
+        const minutesStaleTimestamp = new Date() - 35 * 60 * 1000; // 35 mins stale
+        await act(async () => {
+            render(
+                <StaleDataIndicator
+                    timestamp={minutesStaleTimestamp}
+                    staleMinutesOverride={10}
+                />
+            );
+        });
+
+        expect(screen.getByText("35 minutes ago")).toBeTruthy();
+    });
+
+    it("shows hours if between 1 and 24 hours", async () => {
+        const minutesStaleTimestamp = new Date() - 3 * 60 * 60 * 1000;
+        await act(async () => {
+            render(
+                <StaleDataIndicator
+                    timestamp={minutesStaleTimestamp}
+                    staleMinutesOverride={10}
+                />
+            );
+        });
+
+        expect(screen.getByText("3 hours ago")).toBeTruthy();
+    });
+
+    it("shows days if over 24 hours", async () => {
+        const minutesStaleTimestamp = new Date() - 3 * 24 * 60 * 60 * 1000;
+        await act(async () => {
+            render(
+                <StaleDataIndicator
+                    timestamp={minutesStaleTimestamp}
+                    staleMinutesOverride={10}
+                />
+            );
+        });
+
+        expect(screen.getByText("3 days ago")).toBeTruthy();
+    });
+
+    it("parses singular correctly", async () => {
+        const minutesStaleTimestamp = new Date() - 1 * 60 * 1000;
+        await act(async () => {
+            render(
+                <StaleDataIndicator
+                    timestamp={minutesStaleTimestamp}
+                    staleMinutesOverride={0}
+                />
+            );
+        });
+
+        expect(screen.getByText("1 minute ago")).toBeTruthy();
+    });
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8116945/108561197-cf7dfc80-72cb-11eb-9c79-66e7f2d71bd6.png)
approved UX by Daniel

when more than 8 minutes old, shows timestamp (X:XX AM/PM)
when yesterday, shows yesterday
when older than yesterday, shows date (we should arguably filter these out though, I'll make a new issue)