### PR TITLE
Clean up validateDOMNesting console warnings

### DIFF
--- a/src/components/HelpDialog.js
+++ b/src/components/HelpDialog.js
@@ -38,8 +38,11 @@ export default function HelpDialog({
             <Dialog open={helpOpen} onClose={() => setHelpOpen(false)}>
                 <DialogTitle id="about-dialog-title">{title}</DialogTitle>
                 <DialogContent>
-                    <DialogContentText id="about-dialog-description">
-                        <p>{text}</p>
+                    <DialogContentText
+                        id="about-dialog-description"
+                        component={typeof text === "string" ? "p" : "div"}
+                    >
+                        {text}
                     </DialogContentText>
                     <Button onClick={() => setHelpOpen(false)}>OK</Button>
                 </DialogContent>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -119,7 +119,10 @@ function AboutDialog(props) {
                 {"About this Website"}
             </DialogTitle>
             <DialogContent>
-                <DialogContentText id="about-dialog-description">
+                <DialogContentText
+                    id="about-dialog-description"
+                    component="div"
+                >
                     <p>
                         This website was created by{" "}
                         <a
@@ -165,34 +168,38 @@ function ResourcesDialog(props) {
         <Dialog {...props}>
             <DialogTitle id="about-dialog-title">{"Resources"}</DialogTitle>
             <DialogContent>
-                <DialogContentText id="about-dialog-description">
+                <DialogContentText
+                    id="about-dialog-description"
+                    component="div"
+                >
                     <p>
                         There are two other websites for the state of
                         Massachusetts that compile information on vaccine
                         availability. They are:
-                        <ul>
-                            <li>
-                                <a
-                                    href="https://vaccinatema.com"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                >
-                                    Vaccinate MA
-                                </a>{" "}
-                                (volunteer-run)
-                            </li>
-                            <li>
-                                <a
-                                    href="https://vaxfinder.mass.gov"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                >
-                                    Vax Finder
-                                </a>{" "}
-                                (state-run)
-                            </li>
-                        </ul>
                     </p>
+
+                    <ul>
+                        <li>
+                            <a
+                                href="https://vaccinatema.com"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Vaccinate MA
+                            </a>{" "}
+                            (volunteer-run)
+                        </li>
+                        <li>
+                            <a
+                                href="https://vaxfinder.mass.gov"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Vax Finder
+                            </a>{" "}
+                            (state-run)
+                        </li>
+                    </ul>
                     <p>
                         For more information on the vaccine rollout in
                         Massachusetts, visit{" "}


### PR DESCRIPTION
Console shows validateDOMNesting warnings when you open the About/Resources menu options, or when you open the "This site may be restricted" HelpDialogs in the appointment table. This PR addresses that.

Thanks!