### PR TITLE
Display total available appointments for a location.

### DIFF
--- a/src/components/Availability.js
+++ b/src/components/Availability.js
@@ -36,6 +36,10 @@ export default function Availability({ entry }) {
                 </div>
             );
         } else {
+            const totalAavailableSlots = availableSlots.reduce(
+                (total, slot) => total + slot.numberAvailableAppointments,
+                0
+            );
             return (
                 <div>
                     {availableSlots.map((slot) => (
@@ -47,6 +51,11 @@ export default function Availability({ entry }) {
                             }`}
                         </div>
                     ))}
+                    {totalAavailableSlots > 1 && availableSlots.length > 0 && (
+                        <div>
+                            {`Total available: ${totalAavailableSlots} slots`}
+                        </div>
+                    )}
                 </div>
             );
         }

--- a/src/components/Availability.test.js
+++ b/src/components/Availability.test.js
@@ -49,3 +49,40 @@ it("shows total slots if availability has no content", async () => {
     });
     expect(screen.queryByText("45 slots")).toBeTruthy();
 });
+
+it("shows total slots across all available days", async () => {
+    await act(async () => {
+        render(
+            <Availability
+                entry={{
+                    hasAppointments: true,
+                    appointmentData: {
+                        "10/11/2021": {
+                            hasAvailability: true,
+                            numberAvailableAppointments: 35,
+                        },
+                        "10/12/2021": {
+                            hasAvailability: true,
+                            numberAvailableAppointments: 35,
+                        },
+                    },
+                }}
+            />
+        );
+    });
+    expect(screen.queryByText("Total available: 70 slots")).toBeTruthy();
+});
+
+it("does not show total slots across all available days if there aren't any", async () => {
+    await act(async () => {
+        render(
+            <Availability
+                entry={{
+                    hasAppointments: false,
+                    totalAvailability: 0,
+                }}
+            />
+        );
+    });
+    expect(screen.queryByText("Total available")).toBeFalsy();
+});


### PR DESCRIPTION
Addressing the enhancement in https://github.com/livgust/macovidvaccines.com/issues/36 to display the total available appointments for a location.