### PR TITLE
add March 11 eligibility note

### DIFF
--- a/src/components/StateEligibility.js
+++ b/src/components/StateEligibility.js
@@ -109,8 +109,8 @@ export default function StateEligibility() {
                                 rel="noreferrer"
                                 target="_blank"
                             >
-                                Pre-K to 12 Teachers and Staff, Early Educators,
-                                and Child Care Workers
+                                Pre-K to 12 teachers and staff, early educators,
+                                and child care workers
                             </a>
                         </EligibilityGroupItem>
                     </List>

--- a/src/components/StateEligibility.js
+++ b/src/components/StateEligibility.js
@@ -98,6 +98,20 @@ export default function StateEligibility() {
                                 etc.)
                             </a>
                         </EligibilityGroupItem>
+                        {/* TODO - remove the following div after March 11, and update link to be appropriate link from https://www.mass.gov/covid-19-vaccine*/}
+                        <br></br>
+                        <br></br>
+                        <div>Eligible to sign up starting March 11: </div>
+                        <br></br>
+                        <EligibilityGroupItem>
+                            <a
+                                href="https://www.mass.gov/info-details/massachusetts-covid-19-vaccination-phases"
+                                rel="noreferrer"
+                                target="_blank"
+                            >
+                                Early education/daycare, and K-12 workers
+                            </a>
+                        </EligibilityGroupItem>
                     </List>
                 </AccordionDetails>
             </Accordion>

--- a/src/components/StateEligibility.js
+++ b/src/components/StateEligibility.js
@@ -109,7 +109,8 @@ export default function StateEligibility() {
                                 rel="noreferrer"
                                 target="_blank"
                             >
-                                Early education/daycare, and K-12 workers
+                                Pre-K to 12 Teachers and Staff, Early Educators,
+                                and Child Care Workers
                             </a>
                         </EligibilityGroupItem>
                     </List>

--- a/src/components/StateEligibility.js
+++ b/src/components/StateEligibility.js
@@ -94,7 +94,7 @@ export default function StateEligibility() {
                                 rel="noreferrer"
                                 target="_blank"
                             >
-                                People in Phase 1 (Health care, nursing homes,
+                                People in Phase 1 (healthcare, nursing homes,
                                 etc.)
                             </a>
                         </EligibilityGroupItem>


### PR DESCRIPTION
This morning there was a press conference update from Baker: https://www.wcvb.com/article/teachers-press-baker-to-offer-covid-19-vaccine-after-biden-directs-states-to-vaccinate-educators/35706923

I'm updating the eligibility section to note March 11 educator eligibility.

Before: 
<img width="1270" alt="Screen Shot 2021-03-03 at 11 23 44 AM" src="https://user-images.githubusercontent.com/10677676/109837474-375d0d00-7c13-11eb-8736-702c1e5c7c90.png">

After: 
<img width="1272" alt="Screen Shot 2021-03-03 at 11 23 32 AM" src="https://user-images.githubusercontent.com/10677676/109837493-3b892a80-7c13-11eb-968a-482c55ac2805.png">

Will make a ticket to remove this on March 11 (integrate the educator eligibility into the normal section). 
