### PR TITLE
Synced checkboxes in both FilterPanels.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,5 @@
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
+
 import Alert from "@material-ui/lab/Alert";
 import AlertTitle from "@material-ui/lab/AlertTitle";
 import ArrowBack from "@material-ui/icons/ArrowBack";
@@ -77,8 +79,11 @@ function App() {
     const [data, setData] = useState([]);
     const [ready, setReady] = useState(false);
     const [errorMessage, setErrorMessage] = useState();
-    const [filters, setFilters] = useState({});
     const [mobileOpen, setMobileOpen] = React.useState(false);
+
+    // State variables for the two FilterPanels so that both update together
+    const [filters, setFilters] = useState({});
+    const [onlyShowAvailable, setOnlyShowAvailable] = useState(true);
 
     useEffect(() => {
         getAppointmentData()
@@ -129,6 +134,8 @@ function App() {
                                 <FilterPanel
                                     data={data}
                                     onChange={setFilters}
+                                    onlyShowAvailable={onlyShowAvailable}
+                                    setOnlyShowAvailable={setOnlyShowAvailable}
                                 />
                             </Drawer>
                         </Hidden>
@@ -144,6 +151,8 @@ function App() {
                                 <FilterPanel
                                     data={data}
                                     onChange={setFilters}
+                                    onlyShowAvailable={onlyShowAvailable}
+                                    setOnlyShowAvailable={setOnlyShowAvailable}
                                 />
                             </Drawer>
                         </Hidden>

--- a/src/components/FilterPanel.js
+++ b/src/components/FilterPanel.js
@@ -34,6 +34,7 @@ function AvailabilityFilter(props) {
     const classes = useStyles();
 
     const handleChange = (e) => {
+        props.setOnlyShowAvailable(e.target.checked);
         props.onChange({
             ...props,
             [e.target.name]: e.target.checked,
@@ -99,12 +100,20 @@ function VaxTypeFilter(props) {
 */
 
 export default function FilterPanel(props) {
+    const {
+        dataIgnored,
+        onChange,
+        onlyShowAvailable,
+        setOnlyShowAvailable,
+    } = props;
+
     const classes = useStyles();
     const theme = useTheme();
     const mdSize = useMediaQuery(theme.breakpoints.up("md"));
 
     const [appointmentFilter, setAppointmentFilter] = useState({
-        onlyShowAvailable: true,
+        onlyShowAvailable: onlyShowAvailable,
+        setOnlyShowAvailable: setOnlyShowAvailable,
     });
     /*
     const [vaxTypeFilter, setVaxTypeFilter] = useState({
@@ -112,8 +121,6 @@ export default function FilterPanel(props) {
         include: [],
     });
 */
-
-    const { dataIgnored, onChange } = props;
 
     /*   useEffect(() => {
         const vaxTypes = Array.from(
@@ -182,7 +189,8 @@ export default function FilterPanel(props) {
 
             <Grid item xs={12}>
                 <AvailabilityFilter
-                    onlyShowAvailable={appointmentFilter.onlyShowAvailable}
+                    onlyShowAvailable={onlyShowAvailable}
+                    setOnlyShowAvailable={setOnlyShowAvailable}
                     onChange={setAppointmentFilter}
                 />
             </Grid>


### PR DESCRIPTION
_@livgust wrote in a previous review:_
> I was only able to look a little bit but I noticed 2 things:
> 
> 1. clicking the "Has Available Appointments" checkbox is REALLY slow. I think part of it is because (left a comment above) whenever it's clicked we're also re-filtering out stale entries. That's added computation we don't need.
> 2. If you deselect "Has Available Appointments" and then resize the window such that the display changes (if the side bar was docked before, now it's not, or vice versa) when you open the filters again the checkbox is checked even though you deselected it. The state of the checkbox should refer to the same React Hook ("useState" variable) regardless of visuals.
> 
> I'm not sure how much you're planning on addressing within this PR so let me know if you want me to ignore this and have it be dealt with later (but obviously before pushing to `master`)

(1) was fixed in another PR and has already been merged.
This fixes part (2) above.  The two checkboxes are synced with a common "useState" variable.

I'm a little disappointed with the structure of this fix because it creates a state linkage between the App and FilterPanel because there are TWO FilterPanels (one permanent, one temporary for mobile).  As we add more filters to the FilterPanel, we are going to have to add more state to the App.  _This is just not very modular._ There is probably a better way to accomplish this, but I'm currently at a loss on how to do that.

It still appears to be calling the filtering code twice when a checkbox is toggled.  I have no idea why this is the case. Not the end of the world, but it is "added computation we don't need".