### PR TITLE
StaleDataIndicatorTest.js: 1-12, not 0-11

### DIFF
--- a/src/components/StaleDataIndicator.test.js
+++ b/src/components/StaleDataIndicator.test.js
@@ -33,12 +33,12 @@ describe("staleness messaging", () => {
         function padMinutes(minutes) {
             return minutes < 10 ? `0${minutes}` : minutes;
         }
+        // We need 1 PM - 12 PM, not 0 PM - 11 PM, so plus-11-mod-12-plus-1:
+        const hours = ((timestampDate.getHours() + 11) % 12) + 1;
+        const minutes = padMinutes(timestampDate.getMinutes());
+        const AMPM = timestampDate.getHours() >= 12 ? "PM" : "AM";
         expect(
-            screen.getByText(
-                `Last updated ${timestampDate.getHours() % 12}:${padMinutes(
-                    timestampDate.getMinutes()
-                )} ${timestampDate.getHours() >= 12 ? "PM" : "AM"}`
-            )
+            screen.getByText(`Last updated ${hours}:${minutes} ${AMPM}`)
         ).toBeTruthy();
     });
 


### PR DESCRIPTION
  That is, time (+11 mod 12 ) +1, because +11+1 = 12 = 0 mod 12.

Use some variables (consts) for clarity, this is a little too much
math for template literals.

Please note this fix only is needed between 12:00 and 12:59pm