### PR TITLE
Invalid (or Unknown) ZIP Codes sort by location.

### DIFF
--- a/src/components/FilterPanel.js
+++ b/src/components/FilterPanel.js
@@ -13,7 +13,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import Container from "@material-ui/core/Container";
 import { hasSignUpLink } from "./SignUpLink";
-import { getDistance } from "geolib";
+import { convertDistance, getDistance } from "geolib";
 import { setSortBy } from "../services/appointmentData.service";
 import Cookies from "universal-cookie";
 
@@ -224,14 +224,19 @@ export default function FilterPanel(props) {
                         const myCoordinates = usZips[zipCodeFilter.zipCode];
                         if (myCoordinates) {
                             setSortBy("miles");
-                            const metersPerMile = 1609.34;
                             d.miles = Math.round(
-                                getDistance(myCoordinates, d.coordinates, 1) /
-                                    metersPerMile
+                                convertDistance(
+                                    getDistance(
+                                        myCoordinates,
+                                        d.coordinates,
+                                        1
+                                    ),
+                                    "mi"
+                                )
                             );
 
                             // Is the location within the range specified?
-                            return d.miles < zipCodeFilter.miles;
+                            return d.miles <= zipCodeFilter.miles;
                         }
                     }
                 }

--- a/src/components/FilterPanel.js
+++ b/src/components/FilterPanel.js
@@ -221,9 +221,9 @@ export default function FilterPanel(props) {
                 if (d) {
                     const zipValid = zipCodeFilter.zipCode.match(/\d{5}/);
                     if (zipValid) {
-                        setSortBy("miles");
                         const myCoordinates = usZips[zipCodeFilter.zipCode];
                         if (myCoordinates) {
+                            setSortBy("miles");
                             const metersPerMile = 1609.34;
                             d.miles = Math.round(
                                 getDistance(myCoordinates, d.coordinates, 1) /
@@ -233,11 +233,12 @@ export default function FilterPanel(props) {
                             // Is the location within the range specified?
                             return d.miles < zipCodeFilter.miles;
                         }
-                    } else {
-                        setSortBy("location");
                     }
                 }
-                return true; // include all for now.
+                // No zipcode was provided or
+                // was unable to find coordinates for the specified zipcode
+                setSortBy("location");
+                return true;
             },
             /*
             vaxType: (d) => {


### PR DESCRIPTION
The  `us-Zips` library is based on ZCTAs (ZIP Code Tabulation Areas) and does not contain every ZIP Code.  Basically, just ZIP Codes with populations attached.  This commonly excludes PO Box zip codes and "unique" ZIP Codes like 12345.  I think that USPS probably just mapped 12345 as unused because of the common pattern and just assigned to Schenectady, NY because they other 123xx codes.

Code was updated to use the default "location sort order" if the ZIP code is invalid or doesn't have coordinates.  It was previously defaulting to the last computation at reported in Issue #118  