### PR TITLE
UX: LocationCard visual changes

### DIFF
--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -193,7 +193,7 @@ function RestrictionNotifier({ entry }) {
                 }
             >
                 <Typography className={classes.restrictionWarning}>
-                    Important Eligibility Notice
+                    Information about eligibility
                 </Typography>
             </HelpDialog>
         );
@@ -213,13 +213,13 @@ function LocationCard({ entry, className, onlyShowAvailable }) {
                     }
                     subheader={
                         <>
-                            <RestrictionNotifier entry={entry} />
                             <div>
                                 {entry.city}{" "}
                                 {sortedByMiles()
                                     ? `(${entry.miles} miles)`
                                     : ""}
                             </div>
+                            <RestrictionNotifier entry={entry} />
                             <StaleDataIndicator timestamp={entry.timestamp} />
                         </>
                     }

--- a/src/components/MoreInformation.js
+++ b/src/components/MoreInformation.js
@@ -50,8 +50,7 @@ export default function MoreInformation({ entry }) {
                                 rel="noreferrer"
                                 href={googleMapsLink}
                             >
-                                {entry.streetAddress}, {entry.city}, MA
-                                {entry.zip}
+                                {`${entry.streetAddress}, ${entry.city}, MA ${entry.zip}`}
                             </a>
                         </div>
                     )}

--- a/src/components/StaleDataIndicator.js
+++ b/src/components/StaleDataIndicator.js
@@ -1,5 +1,6 @@
 import { makeStyles } from "@material-ui/core";
 import HistoryOutlinedIcon from "@material-ui/icons/HistoryOutlined";
+import React from "react";
 
 // any location with data older than this will be labeled as "stale"
 export const staleMinutesDefault = 8; // unit is Minutes
@@ -59,7 +60,10 @@ export default function StaleDataIndicator({
 
         return (
             <div className={classes.staleIndicator}>
-                <HistoryOutlinedIcon className={classes.staleIcon} />
+                <HistoryOutlinedIcon
+                    fontSize="small"
+                    className={classes.staleIcon}
+                />
                 {message}
             </div>
         );


### PR DESCRIPTION
There have been a number of items suggested in the #ux channel.  This PR address a few of them.

1. Keep the city near the location
2. There was no space separating MA and ZIP Code in MoreInformation.... was ",MA01760".  Now ",MA 01760"
3. Changed the size of the "stale icon" to match the "restriction icon"
4. Changed "**Important Eligibility Notice**" to "**Information about eligibility**" as recommended in the [#ux channel by Daniel](https://macovidvaccines.slack.com/archives/C01N7C2G2KF/p1614795429083700)

**BEFORE:**
![image](https://user-images.githubusercontent.com/546007/110213465-29ef8f00-7e6e-11eb-931e-6409439067f5.png)

**AFTER:** _(the data wasn't stale on the 2nd screen shot! The icon is the same size as the restriction)_
![image](https://user-images.githubusercontent.com/546007/110213454-1b08dc80-7e6e-11eb-9975-4c8cf8b2c0c0.png)
