### PR TITLE
Refactor AlertBanner out of App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@
 
 import Alert from "@material-ui/lab/Alert";
 import AlertTitle from "@material-ui/lab/AlertTitle";
+import AlertBanner from "./components/AlertBanner";
 import { Button, makeStyles, MuiThemeProvider } from "@material-ui/core";
 import CovidAppointmentTable from "./CovidAppointmentTable";
 import Drawer from "@material-ui/core/Drawer";
@@ -12,7 +13,6 @@ import {
     getAppointmentData,
 } from "./services/appointmentData.service";
 import Grid from "@material-ui/core/Grid";
-//import { Alert, AlertTitle } from "@material-ui/lab";
 import Hidden from "@material-ui/core/Hidden";
 import Loader from "react-loader";
 import Menu from "./components/Menu";
@@ -22,20 +22,6 @@ import theme from "./theme";
 import StateEligibility from "./components/StateEligibility";
 
 const drawerWidth = 300;
-
-/* Alert to put under page title when necessary
-const alert = new Date() > new Date("2021-03-04T06:00:00-05:00") && (
-    <>
-        <Alert severity="warning">
-            <AlertTitle>Thursday, March 4</AlertTitle>
-            Due to high demand, the MA vaccination websites are experiencing
-            technical difficulties. Once the issues are resolved, their
-            locations will appear on this website.
-        </Alert>
-        <br />
-    </>
-);
-*/
 
 const useStyles = makeStyles((theme) => ({
     main: {
@@ -179,6 +165,7 @@ function App() {
                             <h1 className={classes.heading}>
                                 MA Covid Vaccine Appointments
                             </h1>
+                            <AlertBanner />
                             <StateEligibility />
                             <Hidden mdUp implementation="css">
                                 <Button

--- a/src/components/AlertBanner.js
+++ b/src/components/AlertBanner.js
@@ -9,30 +9,52 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
+/* There are four severity levels each has its own icon built-in
+ *  error   - red
+ *  warning - orange (** this is what you should probably use)
+ *  info    - blue
+ *  success - green
+ */
+/* The "-05:00" at the end of the dates adjust from EST to UTC
+ * NOTE: DST begins on 3/14/2021 when the offset becomes "-04:00"
+ * NOTE: EST begins on 11/7/2021 when the offset becomes "-05:00"
+ */
 const alerts = [
-    /*    {
-        startDate: "2021-03-04T06:00:00-05:00",
-        endDate: "2021-03-04T09:00:00-05:00",
-        severity: "warning",
+    /*
+    {
+        startDate: "2021-03-04T06:00:00-05:00", // current timezone offset is at the end
+        endDate: "2021-03-24T09:00:00-05:00",
+        severity: "warning", // one of "error", "info", "success", "warning"
         title: "Thursday, March 4",
         contents:
             "Due to high demand, the MA vaccination websites are experiencing technical difficulties. Once the issues are resolved, their locations will appear on this website.",
-    },*/
+    },
+*/
 ];
 
 export default function AlertBanner() {
     const classes = useStyles();
 
+    // No alerts? Then we're done!
+    if (!alerts.length) {
+        return false;
+    }
+
+    // Filter all of the timely alerts
     const now = new Date();
-    return alerts.map((alert) => {
-        return new Date(alert.startDate) <= now &&
-            now < new Date(alert.endDate) ? (
+    const timelyAlerts = alerts.filter((alert) => {
+        return (
+            new Date(alert.startDate) <= now && now < new Date(alert.endDate)
+        );
+    });
+
+    // Output an Alert for each of the remaining timely alerts
+    return timelyAlerts.map((alert) => {
+        return (
             <Alert severity={alert.severity} className={classes.alertBanner}>
                 <AlertTitle>{alert.title}</AlertTitle>
                 {alert.contents}
             </Alert>
-        ) : (
-            <></>
         );
     });
 }

--- a/src/components/AlertBanner.js
+++ b/src/components/AlertBanner.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
 const alerts = [
     /*    {
         startDate: "2021-03-04T06:00:00-05:00",
-        endDate: "2021-03-24T09:00:00-05:00",
+        endDate: "2021-03-04T09:00:00-05:00",
         severity: "warning",
         title: "Thursday, March 4",
         contents:

--- a/src/components/AlertBanner.js
+++ b/src/components/AlertBanner.js
@@ -1,0 +1,38 @@
+import { makeStyles } from "@material-ui/core/styles";
+import Alert from "@material-ui/lab/Alert";
+import AlertTitle from "@material-ui/lab/AlertTitle";
+
+const useStyles = makeStyles((theme) => ({
+    alertBanner: {
+        marginBottom: theme.spacing(2),
+        display: "flex",
+    },
+}));
+
+const alerts = [
+    /*    {
+        startDate: "2021-03-04T06:00:00-05:00",
+        endDate: "2021-03-24T09:00:00-05:00",
+        severity: "warning",
+        title: "Thursday, March 4",
+        contents:
+            "Due to high demand, the MA vaccination websites are experiencing technical difficulties. Once the issues are resolved, their locations will appear on this website.",
+    },*/
+];
+
+export default function AlertBanner() {
+    const classes = useStyles();
+
+    const now = new Date();
+    return alerts.map((alert) => {
+        return new Date(alert.startDate) <= now &&
+            now < new Date(alert.endDate) ? (
+            <Alert severity={alert.severity} className={classes.alertBanner}>
+                <AlertTitle>{alert.title}</AlertTitle>
+                {alert.contents}
+            </Alert>
+        ) : (
+            <></>
+        );
+    });
+}


### PR DESCRIPTION
Created a separate component for the site banner.  This alert appears at the top of the site (usually on Thursday mornings).

This should eliminate having to deal with merge conflicts on App.js when we are just changing the banner text.

Fixes a spacing issue with css that was previously accomplished with a "<br />" after the alert

Added new functionality:
**startDate** and **endDate** so we can have the alert appear and vanish at predetermined intervals.  There is a sample alert from last week that is commented out in the file.