### PR TITLE
AlertBanner,StateEligibility: Correct React key warnings

### DIFF
--- a/src/components/AlertBanner.js
+++ b/src/components/AlertBanner.js
@@ -64,9 +64,13 @@ export default function AlertBanner() {
     });
 
     // Output an Alert for each of the remaining timely alerts
-    return timelyAlerts.map((alert) => {
+    return timelyAlerts.map((alert, index) => {
         return (
-            <Alert severity={alert.severity} className={classes.alertBanner}>
+            <Alert
+                severity={alert.severity}
+                key={index}
+                className={classes.alertBanner}
+            >
                 <AlertTitle>{alert.title}</AlertTitle>
                 <div dangerouslySetInnerHTML={{ __html: alert.contents }} />
                 {alert.button ? (

--- a/src/components/StateEligibility.js
+++ b/src/components/StateEligibility.js
@@ -159,7 +159,7 @@ export default function StateEligibility() {
                                     {group.list.map((criterion, index) => (
                                         <CriterionItem
                                             criterion={criterion}
-                                            index={index}
+                                            key={"criterion" + index}
                                             classes={classes}
                                         />
                                     ))}
@@ -185,16 +185,15 @@ function CriterionGroup({ className, group }) {
     );
 }
 
-function CriterionItem({ index, criterion, classes }) {
+function CriterionItem({ criterion, classes }) {
     const now = new Date();
 
     // skip any criteria that haven't started yet.
     if (criterion.startDate && now < new Date(criterion.startDate)) {
         return false;
     }
-
     return (
-        <ListItem key={"item" + index} className={classes.listItem}>
+        <ListItem className={classes.listItem}>
             <ListItemIcon className={classes.listItemIcon}>
                 <PeopleIcon color={criterion.color} />
             </ListItemIcon>


### PR DESCRIPTION
Fixes [much of] #142.

`<Alert/>`s are siblings requiring a `key`. This is probably going to be
true anytime we produce React elements with .map(), I guess. Get used to it?

`<CriterionItem/>`s are now also such siblings, so their `<ListItem/>`
children no longer are. Move the key to the former, and eliminate
passing the extra `index` to CriterionItem().