### PR TITLE
Missing space in addresses

### DIFF
--- a/src/components/MoreInformation.js
+++ b/src/components/MoreInformation.js
@@ -58,7 +58,7 @@ export default function MoreInformation({ entry }) {
                                 rel="noreferrer"
                                 href={googleMapsLink}
                             >
-                                {entry.streetAddress}, {entry.city}, MA
+                                {entry.streetAddress}, {entry.city}, MA{" "}
                                 {entry.zip}
                             </Link>
                         </div>


### PR DESCRIPTION
There was no space between the state and the ZIP Code because of the new line in the code.

17 Corinth St, Roslindale, MA 02131 (was 17 Corinth St, Roslindale, MA02131)