### PR TITLE
fast-fix: Drop tooStale filter from 60 minutes to 20 minutes

### DIFF
--- a/src/services/appointmentData.service.js
+++ b/src/services/appointmentData.service.js
@@ -12,7 +12,7 @@ dayjs.extend(utc);
 export let dataNow = dayjs();
 
 // any location with data older than this will not be displayed at all
-const tooStaleMinutes = 60; // unit in minutes
+const tooStaleMinutes = 20; // unit in minutes
 
 export function combineMoreInformation(moreInfo) {
     if (hasSameInformationText(moreInfo)) {


### PR DESCRIPTION
We're seeing Walgreens with 1 or 2 appointments that are more than 20 minutes stale, those are not bookable.
Continue to tweak this as time goes on.