### PR TITLE
Avoid foo.hasOwnProperty() per eslint:no-prototype-builtins

### DIFF
--- a/src/services/appointmentData.service.js
+++ b/src/services/appointmentData.service.js
@@ -149,7 +149,7 @@ export function getAppointmentData() {
             let testData = require("../test/devtest.json");
 
             // If it has 'body', then this looks like something pasted from a browser (View Source)
-            if (testData.hasOwnProperty("body")) {
+            if (Object.prototype.hasOwnProperty.call(testData, "body")) {
                 if (typeof testData.body == "object") {
                     testData = testData.body;
                 } else {


### PR DESCRIPTION
Instead use the more "fun" and seemingly excessively verbose:
	Object.prototype.hasOwnProperty.call(foo, "prop")

See https://eslint.org/docs/rules/no-prototype-builtins
but basically not all objects need have the methods from
Object.prototype in EMCAScript 5.1, and even if they do they can be
subtly/maliciously overridden.

This tripped me up because I had eslint set to a stricter mode than we do, with `"eslint:recommended"` in my `extends` section of `.eslintrc.js`.

On the other hand, feel free to tell me to "shove it," and that this is needlessly strict and excessively verbose, and we don't need to worry about it