### PR TITLE
Read 'totalAvailability' from json

### DIFF
--- a/src/services/appointmentData.service.js
+++ b/src/services/appointmentData.service.js
@@ -76,6 +76,7 @@ function transformData(data) {
             city: entry.city,
             zip: entry.zip,
             hasAppointments: entry.hasAvailability,
+            totalAvailability: entry.totalAvailability || null,
             appointmentData: availability || null,
             isMassVax: entry.massVax || false,
             signUpLink: entry.signUpLink || null,


### PR DESCRIPTION
Fixes #172 

BaystateHealth, HeywoodHealthcare, and CVS ( in the past ) are returning `totalAvailability` when they can detemine the number of appointments, but not on which day the appointments are on.

Here is a devtest.json file that produces the following location card.
```
{
  "version": 1,
  "timestamp": "2021-03-12T130557Z",
  "results": [
    {
      "name": "Heywood Healthcare",
      "street": "171 Kendall Pond W",
      "city": "Gardner",
      "state": "MA",
      "zip": "01440",
      "signUpLink": "https://gardnervaccinations.as.me/schedule.php",
      "hasAvailability": true,
      "totalAvailability": 12,
      "timestamp": "2021-03-12T13:05:57.896Z",
      "latitude": 42.5864159,
      "longitude": -71.9870586
    }
  ]
}
```

![image](https://user-images.githubusercontent.com/546007/113627924-2c423600-9632-11eb-8604-21db2755eecb.png)
