### PR TITLE
Sort the appointment dates

### DIFF
--- a/src/components/Availability.js
+++ b/src/components/Availability.js
@@ -1,6 +1,7 @@
 import { makeStyles } from "@material-ui/core/styles";
 import { useTranslation } from "react-i18next";
 import Link from "@material-ui/core/Link";
+import dayjs from "dayjs";
 
 const useStyles = makeStyles((theme) => ({
     totalSlotsSummary: {
@@ -100,13 +101,16 @@ export default function Availability({ entry, onlyShowAvailable }) {
                             {`Total available: ${totalAvailableSlots} slots`}
                         </div>
                     )}
-                    {availableSlots.map((slot) => (
-                        <div key={slot.date}>
-                            {`${slot.date}: ${t("availability.slot", {
-                                count: slot.numberAvailableAppointments,
-                            })}`}
-                        </div>
-                    ))}
+                    {availableSlots.map((slot) => {
+                        const displayDate = dayjs(slot.date).format("M/D/YY");
+                        return (
+                            <div key={slot.date}>
+                                {`${displayDate}: ${t("availability.slot", {
+                                    count: slot.numberAvailableAppointments,
+                                })}`}
+                            </div>
+                        );
+                    })}
                 </div>
             );
         }

--- a/src/components/Availability.test.js
+++ b/src/components/Availability.test.js
@@ -72,15 +72,15 @@ it("shows dates and slot numbers when showing all (!onlyShowAvailable)", async (
                 entry={{
                     hasAppointments: true,
                     appointmentData: {
-                        "3/4/21": {
+                        "2021-03-04T00:00:00-05:00": {
                             hasAvailability: false,
                             numberAvailableAppointments: 0,
                         },
-                        "3/5/21": {
+                        "2021-03-05T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 271,
                         },
-                        "3/6/21": {
+                        "2021-03-06T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 272,
                             signUpLink: "https://macovidvaccines.com",
@@ -104,15 +104,15 @@ it("shows dates and slot numbers with single sign up link (when onlyShowAvailabl
                     hasAppointments: true,
                     signUpLink: "https://macovidvaccines.com",
                     appointmentData: {
-                        "3/4/21": {
+                        "2021-03-04T00:00:00-05:00": {
                             hasAvailability: false,
                             numberAvailableAppointments: 0,
                         },
-                        "3/5/21": {
+                        "2021-03-05T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 281,
                         },
-                        "3/6/21": {
+                        "2021-03-06T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 282,
                         },
@@ -168,16 +168,16 @@ it("shows 'Appointments are available, but...' if there aren't any sign up links
                     hasAppointments: true,
                     // no single signUpLink
                     appointmentData: {
-                        "3/4/21": {
+                        "2021-03-04T00:00:00-05:00": {
                             hasAvailability: false,
                             numberAvailableAppointments: 0,
                         },
-                        "3/5/21": {
+                        "2021-03-05T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 291,
                             // no signUpLink -- so should not be in output
                         },
-                        "3/6/21": {
+                        "2021-03-06T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 292,
                             // no signUpLink -- so should not be in output
@@ -199,16 +199,16 @@ it("shows dates and slot numbers even without signUpLink (when !onlyShowAvailabl
                     hasAppointments: true,
                     // no single signUpLink
                     appointmentData: {
-                        "3/4/21": {
+                        "2021-03-04T00:00:00-05:00": {
                             hasAvailability: false,
                             numberAvailableAppointments: 0,
                         },
-                        "3/5/21": {
+                        "2021-03-05T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 291,
                             // no signUpLink
                         },
-                        "3/6/21": {
+                        "2021-03-06T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 292,
                             // no signUpLink
@@ -246,11 +246,11 @@ it("shows total slots across all available days", async () => {
                 entry={{
                     hasAppointments: true,
                     appointmentData: {
-                        "10/11/2021": {
+                        "2021-10-11T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 34,
                         },
-                        "10/12/2021": {
+                        "2021-10-12T00:00:00-05:00": {
                             hasAvailability: true,
                             numberAvailableAppointments: 36,
                         },

--- a/src/components/SignUpLink.js
+++ b/src/components/SignUpLink.js
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { makeStyles } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
 import Select from "@material-ui/core/Select";
@@ -71,10 +72,10 @@ export default function SignUpLink({ entry }) {
                     entry.appointmentData[date].hasAvailability &&
                     entry.appointmentData[date].signUpLink
                 ) {
-                    dateLinkPairs.push([
-                        date,
-                        entry.appointmentData[date].signUpLink,
-                    ]);
+                    dateLinkPairs.push({
+                        date: dayjs(date).format("M/D/YY"),
+                        signUpLink: entry.appointmentData[date].signUpLink,
+                    });
                 }
             }
             if (!dateLinkPairs.length) {
@@ -92,7 +93,7 @@ export default function SignUpLink({ entry }) {
                     <Button
                         variant="contained"
                         color="secondary"
-                        href={dateLinkPairs[0][1]}
+                        href={dateLinkPairs[0].signUpLink}
                         rel="noreferrer"
                         target="_blank"
                     >
@@ -119,15 +120,15 @@ function DropDownWithButton({ dateLinkPairs }) {
                 className={classes.dateSelectDropdown}
             >
                 {dateLinkPairs.map((pair, index) => (
-                    <MenuItem key={pair[0]} value={index}>
-                        {pair[0]}
+                    <MenuItem key={pair.date} value={index}>
+                        {pair.date}
                     </MenuItem>
                 ))}
             </Select>
             <Button
                 variant="contained"
                 color="secondary"
-                href={dateLinkPairs[dateIndexSelected][1]}
+                href={dateLinkPairs[dateIndexSelected].signUpLink}
                 rel="noreferrer"
                 target="_blank"
             >

--- a/src/services/appointmentData.service.js
+++ b/src/services/appointmentData.service.js
@@ -32,17 +32,16 @@ export function hasSameInformationText(moreInfo) {
 }
 
 function transformData(data) {
-    const ourDateFormat = "M/D/YY"; // 3/2
-    // future format?    "ddd, MMM D"; // Tue Mar 2
-
     let mappedData = data.map((entry, index) => {
         let availability = [];
         if (entry.availability) {
             for (const [key, value] of Object.entries(entry.availability)) {
-                let newKey = dayjs(key).format(ourDateFormat);
+                let newKey = dayjs(key).format();
                 availability[newKey] = value;
             }
         }
+
+        sortKeys(availability);
 
         let extraData = entry.extraData;
         if (extraData && extraData["Additional Information"]) {
@@ -56,7 +55,7 @@ function transformData(data) {
                 for (const key of Object.keys(
                     extraData["Additional Information"]
                 )) {
-                    const formattedKey = dayjs(key).format(ourDateFormat);
+                    const formattedKey = dayjs(key).format();
                     if (availability[formattedKey].hasAvailability) {
                         newMoreInfo[formattedKey] =
                             extraData["Additional Information"][key];
@@ -102,6 +101,30 @@ function transformData(data) {
     return mappedData.filter((d) => {
         return !d.timestamp || d.timestamp >= oldestGoodTimestamp;
     });
+}
+
+function sortKeys(theObject) {
+    let key = Object.keys(theObject).sort(function order(key1, key2) {
+        if (key1 < key2) return -1;
+        else if (key1 > key2) return +1;
+        else return 0;
+    });
+
+    // Taking the object in 'temp' object
+    // and deleting the original object.
+    let temp = {};
+
+    for (let i = 0; i < key.length; i++) {
+        temp[key[i]] = theObject[key[i]];
+        delete theObject[key[i]];
+    }
+
+    // Copying the object from 'temp' to
+    // 'original object'.
+    for (let i = 0; i < key.length; i++) {
+        theObject[key[i]] = temp[key[i]];
+    }
+    return theObject;
 }
 
 export function sortData(data, sortKey) {


### PR DESCRIPTION
Fixes #174 The incoming JSON file might send appointmentData in an unsorted order.

All of the keys are now converted to a sortable format "YYYY-MM-DDTHH:mm:ssZ".  The keys are then sorted.
Formatting is left until the time of display in Availability.js and SignUpLink.js

This input data with out-of-sequence dates:
```
      "availability": {
        "4/8/2021": {
          "numberAvailableAppointments": 13,
          "hasAvailability": true
        },
        "4/10/2021": {
          "numberAvailableAppointments": 32,
          "hasAvailability": true
        },
        "4/6/2021": {
          "numberAvailableAppointments": 27,
          "hasAvailability": true
        },
        "4/7/2021": {
          "numberAvailableAppointments": 35,
          "hasAvailability": true
        }
      },
```

Now produces:
![image](https://user-images.githubusercontent.com/546007/113763176-60c3f980-96e7-11eb-8446-5a1c1757f30b.png)
