### PR TITLE
MassVax card updated

### DIFF
--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -233,13 +233,10 @@ function MassVaxCard({ className }) {
                     className={classes.massVaxBoxHeader}
                     title={
                         <div className={classes.locationTitle}>
-                            <span>Preregister for Mass Vaccination Sites</span>
+                            <span>
+                                Preregister for a COVID-19 vaccine appointment
+                            </span>
                         </div>
-                    }
-                    subheader={
-                        <>
-                            <div>Numerous Locations across Massachusetts</div>
-                        </>
                     }
                 />
                 <CardContent>
@@ -251,10 +248,11 @@ function MassVaxCard({ className }) {
                     >
                         preregistration system
                     </a>{" "}
-                    helps you get an appointment at one of the many mass
-                    vaccination locations and regional collaboratives near you.
-                    You’ll receive weekly status updates, and you may opt out at
-                    any time if you find an appointment elsewhere.
+                    makes it easier to request and schedule an appointment at
+                    one of the many mass vaccination locations and regional
+                    collaboratives near you. You’ll receive weekly status
+                    updates, and you may opt out at any time if you find an
+                    appointment elsewhere.
                     <p>
                         We recommend preregistering <i>and</i> using this site
                         &mdash; you may find an appointment at locations not

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -238,14 +238,7 @@ function MassVaxCard({ className }) {
                     }
                     subheader={
                         <>
-                            <div>
-                                Gillette Stadium, Hynes Convention Center,
-                                Reggie Lewis State Track Athletic Center,
-                                Dartmouth - Former Circuit City, Danvers -
-                                Doubletree Hotel, Springfield - Eastfield Mall,
-                                Natick Mall, Marshfield Fairgrounds, Amherst
-                                Bangs Community Center
-                            </div>
+                            <div>Numerous Locations across Massachusetts</div>
                         </>
                     }
                 />
@@ -258,9 +251,10 @@ function MassVaxCard({ className }) {
                     >
                         preregistration system
                     </a>{" "}
-                    helps you get an appointment at one of the mass vaccination
-                    locations. You’ll receive weekly status updates, and you may
-                    opt out at any time if you find an appointment elsewhere.
+                    helps you get an appointment at one of the many mass
+                    vaccination locations and regional collaboratives near you.
+                    You’ll receive weekly status updates, and you may opt out at
+                    any time if you find an appointment elsewhere.
                     <p>
                         We recommend preregistering <i>and</i> using this site
                         &mdash; you may find an appointment at locations not
@@ -269,7 +263,7 @@ function MassVaxCard({ className }) {
                     <Button
                         variant="contained"
                         color="primary"
-                        href="https://vaccineSignUp.mass.gov"
+                        href="https://www.mass.gov/info-details/preregister-for-a-covid-19-vaccine-appointment"
                         rel="noreferrer"
                         target="_blank"
                     >


### PR DESCRIPTION
Fixed #181 

Several additional locations have been added to the Preregistration System recently.  This number currently stands at 7 MassVax sites plus 6 regional collaboratives. The state's site says that "_More locations will continue to be added_."

The text was updated to be more generic so that additional updates to this site will not be necessary as the Commonwealth adds more sites.

In addition, the button was redirected to the state's information page rather than directly sending the user to the registration page.

![image](https://user-images.githubusercontent.com/546007/115118588-e8c0c380-9f71-11eb-9926-6196de5b2fe7.png)
