### PR TITLE
URL Route for ZIP Codes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -49,11 +49,11 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-function App() {
+function App({ zipParam }) {
     return (
         <MuiThemeProvider theme={theme}>
             <Menu />
-            <MainComponent />
+            <MainComponent zipParam={zipParam} />
         </MuiThemeProvider>
     );
 }
@@ -71,7 +71,7 @@ function ErrorMessageAlert({ message }) {
     );
 }
 
-function MainComponent() {
+function MainComponent({ zipParam }) {
     const { t } = useTranslation("main");
     const classes = useStyles();
     const mainContainer = document.getElementById("main-container");
@@ -82,6 +82,13 @@ function MainComponent() {
     const [notificationsOpen, setNotificationsOpen] = useState(false);
 
     let filterCookies = getCookie("filter");
+
+    // If there was a ZIP Code parameter passed in, then set/update the cookie
+    if (zipParam) {
+        filterCookies.filterByZipCode.zipCode = zipParam;
+        setCookie("filter", filterCookies);
+    }
+
     // UX change removed 5 mile radius as an option so this will set cookies
     // previously set to 5 to the next smallest, 10
     // TODO: undo this snippet after sufficient time has passed

--- a/src/Router.js
+++ b/src/Router.js
@@ -16,6 +16,12 @@ export default function AppRouter() {
                     <Route exact path="/">
                         <App />
                     </Route>
+                    <Route
+                        path="/zip/:ZIPCode"
+                        render={({ match }) => (
+                            <App zipParam={match.params.ZIPCode} />
+                        )}
+                    />
                     <Route path="/about">
                         <About />
                     </Route>


### PR DESCRIPTION
Allows for specific ZIP Codes to be specified in the URL.  This would enable local government or news websites to publish a link to MACovidVaccines.com with a targeted _ZIP Code_.  Currently, the default when visiting the site with the plain URL ( https://MACovidVaccines.com ) is to show all locations with available appointments **sorted alphabetically** by the location's name.

For example, Worcester, MA could use the direct URL:
https://MACovidVaccines.com/zip/01601