### PR TITLE
FAST FIX: Zip Route crashed App if no existing cookie

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -85,7 +85,7 @@ function MainComponent({ zipParam }) {
     let filterCookies = getCookie("filter");
 
     // If there was a ZIP Code parameter passed in, then set/update the cookie
-    if (zipParam) {
+    if (zipParam && filterCookies?.filterByZipCode) {
         filterCookies.filterByZipCode.zipCode = zipParam;
         setCookie("filter", filterCookies);
     }


### PR DESCRIPTION
If the user goes to a ZIP code route such as https://www.macovidvaccines.com/zip/01760 **and** there was no pre-existing cookie from visiting the main site first, then the app crashes and the user sees a blank screen.