### PR TITLE
Remove all Preregistration messaging

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -213,26 +213,6 @@ function AboutContent({ className }) {
 
             <h3>Resources</h3>
             <p>
-                The Commonwealth's{" "}
-                <a
-                    href="https://www.mass.gov/info-details/preregister-for-a-covid-19-vaccine-appointment"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    preregistration system
-                </a>{" "}
-                helps you get an appointment at one of the seven mass
-                vaccination locations. You'll receive weekly status updates, and
-                you may opt out at any time if you find an appointment
-                elsewhere.
-            </p>
-
-            <p>
-                We recommend preregistering and using this site — you may find
-                an appointment at locations not covered by preregistration.
-            </p>
-
-            <p>
                 There are two other websites for the state of Massachusetts that
                 compile information on vaccine availability. They are:
                 <ul>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -27,7 +27,7 @@ describe("the App component", function () {
                 render(<App />);
             });
 
-            expect(await screen.findAllByRole("listitem")).toHaveLength(3);
+            expect(await screen.findAllByRole("listitem")).toHaveLength(2);
         });
 
         test("disabling the filter shows all appointment cards", async function () {
@@ -41,7 +41,7 @@ describe("the App component", function () {
             await screen.getByTestId("availability-checkbox").click();
             await screen.getByTestId("apply-filters-button").click();
 
-            expect(await screen.findAllByRole("listitem")).toHaveLength(4);
+            expect(await screen.findAllByRole("listitem")).toHaveLength(3);
         });
     });
 

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -15,8 +15,6 @@ import SignUpLink from "./components/SignUpLink";
 import { sortData } from "./services/appointmentData.service";
 import StaleDataIndicator from "./components/StaleDataIndicator";
 import Typography from "@material-ui/core/Typography";
-import Button from "@material-ui/core/Button";
-import { getCookie, setCookie } from "./services/cookie.service";
 import { useTranslation, Trans } from "react-i18next";
 
 const useStyles = makeStyles((theme) => ({
@@ -41,10 +39,6 @@ const useStyles = makeStyles((theme) => ({
         color: theme.palette.error.dark,
         "padding-right": theme.spacing(1),
     },
-    massVaxBoxHeader: {
-        paddingBottom: 0,
-    },
-    massVaxBox: {},
 }));
 
 export default function CovidAppointmentTable({
@@ -71,7 +65,6 @@ export default function CovidAppointmentTable({
     if (sortedData && sortedData.length) {
         return (
             <div role="list">
-                <MassVaxCard className={classes.cardBox} />
                 <ShowingUnfilteredData
                     showingUnfilteredData={showingUnfilteredData}
                     miles={filterMiles}
@@ -93,7 +86,6 @@ export default function CovidAppointmentTable({
     } else {
         return (
             <div role="list">
-                <MassVaxCard className={classes.cardBox} />
                 <NoAppointmentsAlert />
             </div>
         );
@@ -210,76 +202,6 @@ function LocationCard({ entry, className, onlyShowAvailable, showMiles }) {
                     />
                     <MoreInformation entry={entry} />
                     <SignUpLink entry={entry} />
-                </CardContent>
-            </Card>
-        </div>
-    );
-}
-
-function MassVaxCard({ className }) {
-    const { t } = useTranslation("main");
-    const classes = useStyles();
-
-    if (getCookie("hideMassVax")) {
-        return null;
-    }
-
-    function dismissMassVax() {
-        setCookie("hideMassVax", true);
-        document.getElementById("MassVaxCard").hidden = true;
-    }
-
-    return (
-        <div id="MassVaxCard" role="listitem" className={className}>
-            <Card className={classes.massVaxBox}>
-                <CardHeader
-                    className={classes.massVaxBoxHeader}
-                    title={
-                        <div className={classes.locationTitle}>
-                            <span>{t("mass_vax.title")}</span>
-                        </div>
-                    }
-                />
-                <CardContent>
-                    <Trans ns="main" i18nKey="mass_vax.content">
-                        The Commonwealth’s{" "}
-                        <a
-                            href="https://www.mass.gov/info-details/preregister-for-a-covid-19-vaccine-appointment"
-                            rel="noreferrer"
-                            target="_blank"
-                        >
-                            preregistration system
-                        </a>{" "}
-                        makes it easier to request and schedule an appointment
-                        at one of the many mass vaccination locations and
-                        regional collaboratives near you. You’ll receive weekly
-                        status updates, and you may opt out at any time if you
-                        find an appointment elsewhere.
-                        <p>
-                            We recommend preregistering <i>and</i> using this
-                            site. You may find an appointment at locations not
-                            covered by preregistration.
-                        </p>
-                    </Trans>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        href="https://www.mass.gov/info-details/preregister-for-a-covid-19-vaccine-appointment"
-                        rel="noreferrer"
-                        target="_blank"
-                    >
-                        {t("button.preregister")}
-                    </Button>{" "}
-                    <Button
-                        variant="outlined"
-                        color="default"
-                        style={{ marginLeft: "5px" }}
-                        onClick={dismissMassVax}
-                        rel="noreferrer"
-                        target="_blank"
-                    >
-                        {t("button.dismiss_reminder")}
-                    </Button>
                 </CardContent>
             </Card>
         </div>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -244,7 +244,6 @@ function AboutDialog(props) {
 
 function ResourcesDialog(props) {
     const { t } = useTranslation("main");
-    const classes = useStyles();
     return (
         <Dialog {...props}>
             <DialogTitle id="about-dialog-title">
@@ -255,36 +254,6 @@ function ResourcesDialog(props) {
                     id="about-dialog-description"
                     component="div"
                 >
-                    <Trans ns="main" i18nKey="mass_vax.content">
-                        The Commonwealth’s{" "}
-                        <a
-                            href="https://www.mass.gov/info-details/preregister-for-a-covid-19-vaccine-appointment"
-                            rel="noreferrer"
-                            target="_blank"
-                        >
-                            preregistration system
-                        </a>{" "}
-                        makes it easier to request and schedule an appointment
-                        at one of the many mass vaccination locations and
-                        regional collaboratives near you. You’ll receive weekly
-                        status updates, and you may opt out at any time if you
-                        find an appointment elsewhere.
-                        <p>
-                            We recommend preregistering <i>and</i> using this
-                            site. You may find an appointment at locations not
-                            covered by preregistration.
-                        </p>
-                    </Trans>
-
-                    <Button
-                        variant="contained"
-                        className={classes.resourceButton}
-                        href="https://www.mass.gov/info-details/preregister-for-a-covid-19-vaccine-appointment"
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        {t("button.preregister")}
-                    </Button>
                     <p>{t("resources.other_sites")}</p>
                     <ul>
                         <li>

--- a/src/translations/translations.en.main.json
+++ b/src/translations/translations.en.main.json
@@ -70,10 +70,6 @@
         "paragraph1": "None of the vaccine sites that we monitor currently have available appointments. This website gathers data every minute from COVID-19 vaccine sites across Massachusetts.",
         "paragraph2": "Check back for updated information. For more information on the vaccine rollout in Massachusetts, visit <2>www.mass.gov/covid-19-vaccine</2>."
     },
-    "mass_vax": {
-        "title": "Preregister for a COVID-19 vaccine appointment",
-        "content": "The Commonwealth’s <2> preregistration system</2> makes it easier to request and schedule an appointment at one of the many mass vaccination locations and regional collaboratives near you. You’ll receive weekly status updates, and you may opt out at any time if you find an appointment elsewhere. <p> We recommend preregistering <i>and</i> using this site. You may find an appointment at locations not covered by preregistration.</p>"
-    },
     "location": {
         "miles": "({{count}} mile)",
         "miles_plural": "({{count}} miles)",


### PR DESCRIPTION
The Commonwealth has opened MassVax sites to immediate public appointments.

There is still some `massVax` code remaining, but I left it there since it might be needed to handle historical data that is floating around in the database.