### PR TITLE
Consolidate large pharmacy chains

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -27,7 +27,7 @@ describe("the App component", function () {
                 render(<App />);
             });
 
-            expect(await screen.findAllByRole("listitem")).toHaveLength(3);
+            expect(await screen.findAllByRole("listitem")).toHaveLength(7);
         });
 
         test("disabling the filter shows all appointment cards", async function () {
@@ -41,7 +41,7 @@ describe("the App component", function () {
             await screen.getByTestId("availability-checkbox").click();
             await screen.getByTestId("apply-filters-button").click();
 
-            expect(await screen.findAllByRole("listitem")).toHaveLength(4);
+            expect(await screen.findAllByRole("listitem")).toHaveLength(8);
         });
     });
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -27,7 +27,7 @@ describe("the App component", function () {
                 render(<App />);
             });
 
-            expect(await screen.findAllByRole("listitem")).toHaveLength(2);
+            expect(await screen.findAllByRole("listitem")).toHaveLength(3);
         });
 
         test("disabling the filter shows all appointment cards", async function () {
@@ -41,7 +41,7 @@ describe("the App component", function () {
             await screen.getByTestId("availability-checkbox").click();
             await screen.getByTestId("apply-filters-button").click();
 
-            expect(await screen.findAllByRole("listitem")).toHaveLength(3);
+            expect(await screen.findAllByRole("listitem")).toHaveLength(4);
         });
     });
 

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
         "padding-right": theme.spacing(1),
     },
     pharmacySignUp: {
-        marginTop: theme.spacing(0.5),
+        marginTop: theme.spacing(1),
     },
 }));
 

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -215,11 +215,11 @@ function PharmacySignUp({ href, name }) {
     const { t } = useTranslation("main");
     const classes = useStyles();
     return (
-        <div className={classes.pharmacySignUp}>
+        <li className={classes.pharmacySignUp}>
             <a href={href} target="_blank" rel="noreferrer">
                 {t(name)}
             </a>
-        </div>
+        </li>
     );
 }
 
@@ -239,23 +239,24 @@ function PharmacyChainCard({ className }) {
                 <CardContent>
                     {t("pharmacy.availability")}
                     <br />
-
-                    <PharmacySignUp
-                        href="https://www.cvs.com/immunizations/covid-19-vaccine?icid=cvs-home-hero1-banner-1-link2-coronavirus-vaccine"
-                        name={t("pharmacy.cvs")}
-                    />
-                    <PharmacySignUp
-                        href="https://stopandshopsched.rxtouch.com/rbssched/program/covid19/Patient/Advisory"
-                        name={t("pharmacy.stop_and_shop")}
-                    />
-                    <PharmacySignUp
-                        href="https://www.walgreens.com/findcare/vaccination/covid-19/location-screening"
-                        name={t("pharmacy.walgreens")}
-                    />
-                    <PharmacySignUp
-                        href="https://www.walmart.com/cp/immunizations-flu-shots/1228302"
-                        name={t("pharmacy.walmart")}
-                    />
+                    <ul>
+                        <PharmacySignUp
+                            href="https://www.cvs.com/immunizations/covid-19-vaccine?icid=cvs-home-hero1-banner-1-link2-coronavirus-vaccine"
+                            name={t("pharmacy.cvs")}
+                        />
+                        <PharmacySignUp
+                            href="https://stopandshopsched.rxtouch.com/rbssched/program/covid19/Patient/Advisory"
+                            name={t("pharmacy.stop_and_shop")}
+                        />
+                        <PharmacySignUp
+                            href="https://www.walgreens.com/findcare/vaccination/covid-19/location-screening"
+                            name={t("pharmacy.walgreens")}
+                        />
+                        <PharmacySignUp
+                            href="https://www.walmart.com/cp/immunizations-flu-shots/1228302"
+                            name={t("pharmacy.walmart")}
+                        />
+                    </ul>
                 </CardContent>
             </Card>
         </div>

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -39,6 +39,9 @@ const useStyles = makeStyles((theme) => ({
         color: theme.palette.error.dark,
         "padding-right": theme.spacing(1),
     },
+    pharmacySignUp: {
+        marginTop: theme.spacing(0.5),
+    },
 }));
 
 export default function CovidAppointmentTable({
@@ -65,6 +68,7 @@ export default function CovidAppointmentTable({
     if (sortedData && sortedData.length) {
         return (
             <div role="list">
+                <PharmacyChainCard className={classes.cardBox} />
                 <ShowingUnfilteredData
                     showingUnfilteredData={showingUnfilteredData}
                     miles={filterMiles}
@@ -202,6 +206,56 @@ function LocationCard({ entry, className, onlyShowAvailable, showMiles }) {
                     />
                     <MoreInformation entry={entry} />
                     <SignUpLink entry={entry} />
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+function PharmacySignUp({ href, name }) {
+    const { t } = useTranslation("main");
+    const classes = useStyles();
+    return (
+        <div className={classes.pharmacySignUp}>
+            <a href={href} target="_blank" rel="noreferrer">
+                {t(name)}
+            </a>
+        </div>
+    );
+}
+
+function PharmacyChainCard({ className }) {
+    const { t } = useTranslation("main");
+    const classes = useStyles();
+    return (
+        <div role="listitem" className={className}>
+            <Card>
+                <CardHeader
+                    title={
+                        <div className={classes.locationTitle}>
+                            <span>{t("pharmacy.title")}</span>
+                        </div>
+                    }
+                />
+                <CardContent>
+                    {t("pharmacy.availability")}
+                    <br />
+
+                    <PharmacySignUp
+                        href="https://www.cvs.com/immunizations/covid-19-vaccine?icid=cvs-home-hero1-banner-1-link2-coronavirus-vaccine"
+                        name={t("pharmacy.cvs")}
+                    />
+                    <PharmacySignUp
+                        href="https://stopandshopsched.rxtouch.com/rbssched/program/covid19/Patient/Advisory"
+                        name={t("pharmacy.stop_and_shop")}
+                    />
+                    <PharmacySignUp
+                        href="https://www.walgreens.com/findcare/vaccination/covid-19/location-screening"
+                        name={t("pharmacy.walgreens")}
+                    />
+                    <PharmacySignUp
+                        href="https://www.walmart.com/cp/immunizations-flu-shots/1228302"
+                        name={t("pharmacy.walmart")}
+                    />
                 </CardContent>
             </Card>
         </div>

--- a/src/CovidAppointmentTable.js
+++ b/src/CovidAppointmentTable.js
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
         "padding-right": theme.spacing(1),
     },
     pharmacySignUp: {
-        marginTop: theme.spacing(1),
+        marginTop: theme.spacing(1.2),
     },
 }));
 

--- a/src/services/appointmentData.service.js
+++ b/src/services/appointmentData.service.js
@@ -93,8 +93,16 @@ function transformData(data) {
     // We are going to show a consolidated "Preregistration" card instead.
     // There is still code to display these sites individually in
     // Availability.js and SignupLink.js if we decide to go that way later on.
+    // ALSO.. Filter out all pharmacies
     mappedData = mappedData.filter((d) => {
-        return !d.isMassVax;
+        return (
+            !d.isMassVax &&
+            d.location &&
+            !d.location.startsWith("CVS (") &&
+            !d.location.startsWith("Stop & Shop") &&
+            !d.location.startsWith("Walgreens") &&
+            !d.location.startsWith("Walmart")
+        );
     });
 
     // Pre-Filter the locations that have "non-stale" data

--- a/src/translations/translations.en.main.json
+++ b/src/translations/translations.en.main.json
@@ -100,10 +100,10 @@
     },
     "pharmacy": {
         "title": "Large Pharmacy Chains",
-        "availability": "Vaccines are widely available at the following pharmacy chains.",
-        "cvs": "Sign up at CVS",
-        "walgreens": "Sign up at Walgreens",
-        "walmart": "Sign up at Walmart",
-        "stop_and_shop": "Sign up at Stop & Shop"
+        "availability": "Vaccines are widely available at the following pharmacy chains. Sign up at:",
+        "cvs": "CVS",
+        "walgreens": "Walgreens",
+        "walmart": "Walmart",
+        "stop_and_shop": "Stop & Shop"
     }
 }

--- a/src/translations/translations.en.main.json
+++ b/src/translations/translations.en.main.json
@@ -97,5 +97,13 @@
         "filter_name": "Get notifications by location",
         "detail_title": "Notification details: What to expect",
         "detail_content": "<p>When we see appointments appear, we will notify subscribers in order of proximity. If 5 appointments drop at a local pharmacy, a portion of the nearest subscribers will receive a notification. If 1,000 appointments drop somewhere, everyone will receive a notification as long as the location is within their specified radius. This is due to the cost and computational power needed to send lots of text messages to lots of people. The radius you specify is approximate; we may notify you for a location slightly outside of your radius.</p><p>You can cancel your subscription at any time by replying STOP.</p><p>We will never share your phone number with third parties. We may share aggregated, anonymized data with interested parties (for example, what ZIP Codes our subscribers entered or how many people have subscribed). Your subscription information will be stored in a secure database.</p><p> If these terms change and you are still enrolled in this service, we will notify you.</p>"
+    },
+    "pharmacy": {
+        "title": "Large Pharmacy Chains",
+        "availability": "Vaccines are widely available at the following pharmacy chains.",
+        "cvs": "Sign up at CVS",
+        "walgreens": "Sign up at Walgreens",
+        "walmart": "Sign up at Walmart",
+        "stop_and_shop": "Sign up at Stop & Shop"
     }
 }


### PR DESCRIPTION
Here's the proposal...

1. Remove all CVS, Walgreens, Walmart, and Stop & Shop data from the main feed.  (The Walgreens scraper is currently broken and the Walmart scraper never made it to production)
3. Add a new "Large Pharmacy Chains" card to the top of the listings with links to these 4 major chain pharmacies in Massachusetts.

Since vaccine is widely available at the chains now, we don't really need to be a "store locator" service or even look to see if they have slots anymore.  This will remove lots of locations from our giant list of locations to allow users to find non-pharmacy options in their area.  The Local Boards of Health and MassVax sites now have tens of thousands of slots available.

![image](https://user-images.githubusercontent.com/546007/117844413-a8412680-b24d-11eb-9151-46fd4a0939f7.png)
